### PR TITLE
Pull Request to add examples/webgl_loader_viewer.html to forked dev base

### DIFF
--- a/examples/webgl_loader_viewer.html
+++ b/examples/webgl_loader_viewer.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>three.js webgl - model viewer</title>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+	<style>
+	body {
+		font-family: Monospace;
+		background-color: #000;
+		color: #fff;
+		margin: 0px;
+		overflow: hidden;
+	}
+	#info {
+		color: #fff;
+		position: absolute;
+		top: 10px;
+		width: 100%;
+		text-align: center;
+		z-index: 100;
+		display:block;
+	}
+	#info a, .button { color: #f00; font-weight: bold; text-decoration: underline; cursor: pointer }
+	</style>
+</head>
+
+<body>
+	<div id="info">
+		<a href="http://threejs.org" target="_blank">three.js</a> - Model Viewer test
+		<br>
+		select model:
+		<select id="fileModel" onchange="reloadModel(this.value);">
+			<option value="models/babylon/skull.babylon">models/babylon/skull.babylon</option>
+			<option value="obj/female02/female02.obj">obj/female02/female02.obj</option>
+			<option value="obj/male02/male02.obj">obj/male02/male02.obj</option>
+			<option value="obj/walt/WaltHead.obj">obj/walt/WaltHead.obj</option>
+			<option value="models/awd/simple/simple.awd">models/awd/simple/simple.awd</option>
+			<option value="models/collada/monster/monster.dae">models/collada/monster/monster.dae</option>
+			<option value="models/collada/kawada-hironx.dae">models/collada/kawada-hironx.dae</option>
+			<option value="models/fbx/xsi_man_skinning.fbx">models/fbx/xsi_man_skinning.fbx</option>
+			<option value="models/gltf/duck/glTF/duck.gltf">models/gltf/duck/glTF/duck.gltf</option>
+			<option value="models/json/teapot-claraio.json">models/json/teapot-claraio.json</option>
+			<option value="models/skinned/marine/marine_anims_core.json">models/skinned/marine/marine_anims_core.json</option>
+		</select>
+		<br>
+		Custom model:
+		<input type="text" name="custompath" size="50" id="customModel" value="http://people.sc.fsu.edu/~jburkardt/data/obj/shuttle.obj">
+		<button onclick="reloadModel(getElementById('customModel').value)">Load Custom Model</button>
+		<br>
+	</div>
+
+	<script src="../build/three.js"></script>
+	<script src="js/loaders/BabylonLoader.js"></script>
+	<script src="js/loaders/OBJLoader.js"></script>
+	<script src="js/loaders/AWDLoader.js"></script>
+	<script src="js/loaders/ColladaLoader.js"></script>
+	<script src="js/loaders/FBXLoader.js"></script>
+	<script src="js/loaders/GLTFLoader.js"></script>
+	<script src='js/loaders/MD2Loader.js'></script>
+	<script src="js/controls/OrbitControls.js"></script>
+	<script src="js/libs/dat.gui.min.js"></script>
+	<script>
+
+	var camera, controls, scene, renderer;
+
+	init();
+
+	animate();
+
+	function clearScene() {
+		camera.position.z = 250;
+		scene.scale.x = scene.scale.y = scene.scale.z = 1.0;
+
+		for( var i = scene.children.length - 1; i >= 0; i--){
+			obj = scene.children[i];
+			scene.remove(obj);
+		}
+	}
+
+	function setupLights() {
+		var ambient = new THREE.AmbientLight( 0x101030 );
+		scene.add( ambient );
+
+		var directionalLight = new THREE.DirectionalLight( 0xffeedd );
+		directionalLight.position.set( 0, 0, 1 );
+		scene.add( directionalLight );
+	}
+
+	function reloadModel(objPath)
+	{
+		console.log(objPath);
+
+		var token = objPath.split('.');
+		var fileType = token[token.length-1];
+
+		var onProgress = function ( xhr ) {
+			if ( xhr.lengthComputable ) {
+				var percentComplete = xhr.loaded / xhr.total * 100;
+				console.log( Math.round(percentComplete, 2) + '% downloaded' );
+			}
+		};
+
+		var onError = function ( xhr ) {
+		};
+
+		var manager = new THREE.LoadingManager();
+		manager.onProgress = function ( item, loaded, total ) {
+
+			console.log( item, loaded, total );
+
+		};
+
+		var loader = selectLoader(fileType, manager);
+
+		if (fileType == "dae")
+		{
+			loader.options.convertUpAxis = true;
+		}
+
+		loader.load( objPath , function ( myScene ) {
+
+			OnLoadScene(myScene, fileType);
+
+		}, onProgress, onError );
+	}
+
+	function init() {
+
+		camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 2000 );
+		//camera.position.z = 100;
+		camera.position.z = 250;
+
+		//controls = new THREE.TrackballControls( camera );
+
+		// scene
+
+		scene = new THREE.Scene();
+
+		// texture
+
+		var texture = new THREE.Texture();
+
+		var material = new THREE.MeshBasicMaterial( { color: 'red' } );
+
+		// model
+		var model = 'models/babylon/skull.babylon';
+		reloadModel(model);
+
+		//
+
+		renderer = new THREE.WebGLRenderer();
+		renderer.setPixelRatio( window.devicePixelRatio );
+		renderer.setSize( window.innerWidth, window.innerHeight );
+		document.body.appendChild( renderer.domElement );
+
+		//
+
+		controls = new THREE.OrbitControls( camera, renderer.domElement );
+
+		window.addEventListener( 'resize', onWindowResize, false );
+
+	}
+
+	function OnLoadScene(fileScene, objType)
+	{
+		clearScene();
+		setupLights();
+
+		if (objType == "dae" || objType == "gltf")
+		{
+			fileScene = fileScene.scene;
+			//scene.scale.x = scene.scale.y = scene.scale.z = 0.05;
+		}
+
+		console.log("children:" + fileScene.children.length);
+		var space ="";
+		var childcnt = 0;
+		fileScene.traverse( function ( object ) {
+
+			// improvement - handle nested groups?
+			if ( object.constructor.name == "Group" ) {
+				scene.add(object);
+				childcnt = object.children.length;
+				console.log(space+"constructor: "+object.constructor.name);
+				console.log(space+"children:" + childcnt);
+				if (childcnt > 0)
+				{
+					space = "  ";
+				}
+			}
+			else if ( object.constructor.name == "SkinnedMesh" || object.constructor.name == "Mesh" || object.constructor.name == "Object3D" ) {
+				console.log(space+"child:" + childcnt);
+				console.log(space+"constructor: "+object.constructor.name);
+				object.material = new THREE.MeshPhongMaterial( {
+					color: 0xffffff
+				} );
+
+				if (childcnt == 0)
+				{
+					scene.add(object);
+				}
+				else {
+					childcnt--;
+				}
+			}
+			else {
+				console.log(space+"child:" + childcnt);
+				console.log(space+"constructor: "+object.constructor.name);
+				if (childcnt> 0)
+				{
+					childcnt--;
+				}
+			}
+		} );
+	}
+
+
+	function selectLoader(ext, mgr) {
+		switch(ext)
+		{
+			case "md2":
+				console.log("md2");
+				return new THREE.MD2Loader( mgr );
+			case "babylon":
+				console.log("babylon");
+				return new THREE.BabylonLoader( mgr );
+			case "obj":
+				console.log("obj");
+				return new THREE.OBJLoader( mgr );
+			case "awd":
+				console.log("awd");
+				return new THREE.AWDLoader( mgr );
+			case "dae":
+				console.log("dae");
+				return new THREE.ColladaLoader( mgr );
+			case "fbx":
+				console.log("fbx");
+				return new THREE.FBXLoader( mgr );
+			case "gltf":
+				console.log("gltf");
+				return new THREE.GLTFLoader( mgr );
+			case "json":
+				console.log("json");
+				return new THREE.ObjectLoader( mgr);
+			default:
+				return null;
+		}
+	}
+
+	function onWindowResize() {
+
+		camera.aspect = window.innerWidth / window.innerHeight;
+		camera.updateProjectionMatrix();
+
+		renderer.setSize( window.innerWidth, window.innerHeight );
+
+		controls.handleResize();
+
+	}
+
+	//
+
+	function animate() {
+
+		requestAnimationFrame( animate );
+		render();
+
+	}
+
+	function render() {
+
+		controls.update();
+		renderer.render( scene, camera );
+
+	}
+
+	</script>
+
+</body>
+</html>

--- a/examples/webgl_loader_viewer.html
+++ b/examples/webgl_loader_viewer.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<title>three.js webgl - model viewer</title>
+	<title>three.js webgl - model viewer with OrbitControls</title>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 	<style>
@@ -27,7 +27,7 @@
 
 <body>
 	<div id="info">
-		<a href="http://threejs.org" target="_blank">three.js</a> - Model Viewer test
+		<a href="http://threejs.org" target="_blank">three.js</a> - Model Viewer test with OrbitControls
 		<br>
 		select model:
 		<select id="fileModel" onchange="reloadModel(this.value);">
@@ -47,13 +47,14 @@
 			<option value="models/sea3d/mascot.tjs.sea">models/sea3d/mascot.tjs.sea</option>
 			<option value="models/vrml/house.wrl">models/vrml/house.wrl</option>
 		</select>
+		<button onclick="toggleDiv('debug')">Toggle Debug output</button>
 		<br>
 		Custom model:
 		<input type="text" name="custompath" size="50" id="customModel" value="http://people.sc.fsu.edu/~jburkardt/data/obj/shuttle.obj">
 		<button onclick="reloadModel(getElementById('customModel').value)">Load Custom Model</button>
 		<br>
+		<div id="debug" align="left" style="display: none"></div>
 	</div>
-
 
 	<script src="../build/three.js"></script>
 	<script src="js/loaders/BabylonLoader.js"></script>
@@ -83,7 +84,42 @@
 
 	animate();
 
+	function resetCamera() {
+		// to do: improvement - resetCamera() does not always result in best view
+		// http://stackoverflow.com/questions/11766163/smart-centering-and-scaling-after-model-import-in-three-js
+		// fit camera to object
+		var bBox = new THREE.Box3().setFromObject(scene);
+		var height = bBox.size().y;
+		var dist = height / (2 * Math.tan(camera.fov * Math.PI / 360));
+		var pos = scene.position;
+
+		// fudge factor so the object doesn't take up the whole view
+		camera.position.set(pos.x, pos.y, dist * 3);
+		camera.lookAt(pos);
+	}
+
+	function toggleDiv(id) {
+		var div = document.getElementById(id);
+		div.style.display = (div.style.display == 'block') ? 'none' : 'block';
+	}
+
+	function clearDiv(id) {
+		var div = document.getElementById(id);
+		div.innerHTML = "";
+	}
+
+	function appendDiv(id, extra) {
+		var div = document.getElementById(id);
+		div.innerHTML = div.innerHTML + extra;
+	}
+
+	function debugPrint(text)
+	{
+		appendDiv('debug',text);
+	}
+
 	function clearScene() {
+		clearDiv('debug');
 		camera.position.z = 250;
 		scene.scale.x = scene.scale.y = scene.scale.z = 1.0;
 
@@ -104,8 +140,12 @@
 
 	function reloadModel(objPath)
 	{
-		console.log(objPath);
+		controls.reset();
+		loadModel(objPath);
+	}
 
+	function loadModel(objPath)
+	{
 		var token = objPath.split('.');
 		var fileType = token[token.length-1];
 
@@ -115,10 +155,13 @@
 				fileType = "assimp.json";
  		}
 
+		token = objPath.split('/');
+		var fileName = token[token.length-1];
+
 		var onProgress = function ( xhr ) {
 			if ( xhr.lengthComputable ) {
 				var percentComplete = xhr.loaded / xhr.total * 100;
-				console.log( Math.round(percentComplete, 2) + '% downloaded' );
+				console.log( Math.round(percentComplete, 2) + '% downloaded');
 			}
 		};
 
@@ -143,15 +186,39 @@
 		}
 
 		clearScene();
+
+		//to do: improvement - setupLights() improve to use better lights
 		setupLights();
 
-		//note: sea loader does not use onload function
-
+		//to do: improvement - loader.load() note: sea loader does not use onload function - loader.load 2nd param
 		loader.load( objPath , function ( myScene ) {
 
-			OnLoadScene(myScene, fileType);
+			debugPrint(objPath+"<br>");
+			OnLoadScene(myScene, fileType, fileName);
+			resetCamera();
 
 		}, onProgress, onError );
+
+		//to do: improvement - post loader.load() fixes - handle camera for these files automaticaly
+		if (fileName=="mascot.tjs.sea")
+		{
+			camera.position.z = 2000;
+		}
+		else if (fileName=="house.wrl")
+		{
+			camera.position.z = 30;
+		}
+		else if (fileName=="kawada-hironx.dae"){
+			camera.position.z = 3;
+		}
+		else if (fileName=="duck.gltf"){
+			camera.position.z = 6;
+		}
+		else if (fileName=="Zaghetto.pcd")
+		{
+			//to do: improvement - Zaghetto.pcd need to flip pcd model upside down as needed
+			//to do: improvement - Zaghetto.pcd find correct camera settings
+		}
 	}
 
 	function init() {
@@ -174,7 +241,7 @@
 
 		// model
 		var model = 'models/babylon/skull.babylon';
-		reloadModel(model);
+		loadModel(model);
 
 		//
 
@@ -191,7 +258,7 @@
 
 	}
 
-	function OnLoadScene(fileScene, objType)
+	function OnLoadScene(fileScene, objType, objName)
 	{
 
 		if (objType == "dae" || objType == "gltf" || objType == "sea")
@@ -200,31 +267,41 @@
 			//scene.scale.x = scene.scale.y = scene.scale.z = 0.05;
 		}
 
-		console.log("children:" + fileScene.children.length);
+		debugPrint("root children:" + fileScene.children.length+"<br>");
 		var space ="";
 		var childcnt = 0;
 		fileScene.traverse( function ( object ) {
 
-			// improvement - handle nested groups?
+			//to do: bug - fileScene.traverse() dae error on traversing last child?
+
+			//to do: improvement - fileScene.traverse() handle nested groups?
 			if ( object.constructor.name == "Group" ) {
 				scene.add(object);
 				childcnt = object.children.length;
-				console.log(space+"constructor: "+object.constructor.name);
-				console.log(space+"children:" + childcnt);
+				debugPrint("constructor: "+object.constructor.name+", children:" + childcnt+"<br>");
 				if (childcnt > 0)
 				{
-					space = "  ";
+					space = "++";
 				}
 			}
 			else if ( object.constructor.name == "SkinnedMesh" || object.constructor.name == "Mesh" || object.constructor.name == "Object3D" ) {
-				console.log(space+"child:" + childcnt);
-				console.log(space+"constructor: "+object.constructor.name);
-				/*object.material = new THREE.MeshPhongMaterial( {
-					color: 0xffffff
-				} );*/
+				if (childcnt > 0)
+				{
+					debugPrint(space+"child:" + childcnt+", ");
+				}
+				debugPrint("constructor: "+object.constructor.name+", children: "+object.children.length+"<br>");
+
+				if (objName == "skull.babylon" || objName == "duck.gltf" )
+				{
+					//to do: bug - with gltf file can not move model unless material is changed
+					object.material = new THREE.MeshPhongMaterial( {
+						color: 0xffffff
+					} );
+				}
 
 				if (childcnt == 0)
 				{
+					space = "";
 					scene.add(object);
 				}
 				else {
@@ -235,6 +312,7 @@
 			{
 				if (childcnt == 0)
 				{
+					space = "";
 					scene.add(object);
 				}
 				else {
@@ -242,17 +320,18 @@
 				}
 			}
 			else {
-				console.log(space+"child:" + childcnt);
-				console.log(space+"constructor: "+object.constructor.name);
+					debugPrint(space+"child:" + childcnt+", ");
+					debugPrint(space+"constructor: "+object.constructor.name+", children: "+object.children.length+"<br>");
 				if (childcnt> 0)
 				{
 					childcnt--;
 				}
 			}
 		} );
+
 	}
 
-	//improvement - support Geometry Loaders
+	//to do: improvement - selectLoader()/OnLoadScene() add support for Geometry Loaders
 	//right now only supports Mesh Loaders
 	function selectLoader(ext, mgr) {
 		switch(ext)

--- a/examples/webgl_loader_viewer.html
+++ b/examples/webgl_loader_viewer.html
@@ -42,6 +42,10 @@
 			<option value="models/gltf/duck/glTF/duck.gltf">models/gltf/duck/glTF/duck.gltf</option>
 			<option value="models/json/teapot-claraio.json">models/json/teapot-claraio.json</option>
 			<option value="models/skinned/marine/marine_anims_core.json">models/skinned/marine/marine_anims_core.json</option>
+			<option value="models/assimp/jeep/jeep.assimp.json">models/assimp/jeep/jeep.assimp.json</option>
+			<option value="models/pcd/Zaghetto.pcd">models/pcd/Zaghetto.pcd</option>
+			<option value="models/sea3d/mascot.tjs.sea">models/sea3d/mascot.tjs.sea</option>
+			<option value="models/vrml/house.wrl">models/vrml/house.wrl</option>
 		</select>
 		<br>
 		Custom model:
@@ -50,6 +54,7 @@
 		<br>
 	</div>
 
+
 	<script src="../build/three.js"></script>
 	<script src="js/loaders/BabylonLoader.js"></script>
 	<script src="js/loaders/OBJLoader.js"></script>
@@ -57,10 +62,20 @@
 	<script src="js/loaders/ColladaLoader.js"></script>
 	<script src="js/loaders/FBXLoader.js"></script>
 	<script src="js/loaders/GLTFLoader.js"></script>
-	<script src='js/loaders/MD2Loader.js'></script>
+	<script src="js/loaders/AssimpJSONLoader.js"></script>
+	<script src="js/loaders/PCDLoader.js"></script>
+	<script src="js/loaders/sea3d/SEA3D.js"></script>
+	<script src="js/loaders/sea3d/SEA3DLZMA.js"></script>
+	<script src="js/loaders/sea3d/SEA3DLoader.js"></script>
+	<script src="js/loaders/VRMLLoader.js"></script>
 	<script src="js/controls/OrbitControls.js"></script>
 	<script src="js/libs/dat.gui.min.js"></script>
+	<script src="js/Detector.js"></script>
 	<script>
+
+	if ( ! Detector.webgl ) {
+		Detector.addGetWebGLMessage();
+	}
 
 	var camera, controls, scene, renderer;
 
@@ -94,6 +109,12 @@
 		var token = objPath.split('.');
 		var fileType = token[token.length-1];
 
+		if (fileType == "json")
+		{
+			if (token[token.length-2] == "assimp")
+				fileType = "assimp.json";
+ 		}
+
 		var onProgress = function ( xhr ) {
 			if ( xhr.lengthComputable ) {
 				var percentComplete = xhr.loaded / xhr.total * 100;
@@ -113,10 +134,18 @@
 
 		var loader = selectLoader(fileType, manager);
 
-		if (fileType == "dae")
+		if (fileType == "dae" )
 		{
 			loader.options.convertUpAxis = true;
 		}
+		else if (fileType == "pcd"){
+			//do something to invert upside down
+		}
+
+		clearScene();
+		setupLights();
+
+		//note: sea loader does not use onload function
 
 		loader.load( objPath , function ( myScene ) {
 
@@ -164,10 +193,8 @@
 
 	function OnLoadScene(fileScene, objType)
 	{
-		clearScene();
-		setupLights();
 
-		if (objType == "dae" || objType == "gltf")
+		if (objType == "dae" || objType == "gltf" || objType == "sea")
 		{
 			fileScene = fileScene.scene;
 			//scene.scale.x = scene.scale.y = scene.scale.z = 0.05;
@@ -192,10 +219,20 @@
 			else if ( object.constructor.name == "SkinnedMesh" || object.constructor.name == "Mesh" || object.constructor.name == "Object3D" ) {
 				console.log(space+"child:" + childcnt);
 				console.log(space+"constructor: "+object.constructor.name);
-				object.material = new THREE.MeshPhongMaterial( {
+				/*object.material = new THREE.MeshPhongMaterial( {
 					color: 0xffffff
-				} );
+				} );*/
 
+				if (childcnt == 0)
+				{
+					scene.add(object);
+				}
+				else {
+					childcnt--;
+				}
+			}
+			else if ( object.constructor.name == "Points")
+			{
 				if (childcnt == 0)
 				{
 					scene.add(object);
@@ -215,13 +252,26 @@
 		} );
 	}
 
-
+	//improvement - support Geometry Loaders
+	//right now only supports Mesh Loaders
 	function selectLoader(ext, mgr) {
 		switch(ext)
 		{
-			case "md2":
-				console.log("md2");
-				return new THREE.MD2Loader( mgr );
+			case "wrl":
+				console.log("wrl");
+				return new THREE.VRMLLoader();
+			case "sea":
+				console.log("sea");
+				return new THREE.SEA3D({
+					autoPlay : false, // Auto play animations
+					container : scene // Container to add models
+				} );
+			case "pcd":
+				console.log("pcd");
+				return new THREE.PCDLoader();
+			case "assimp.json":
+				console.log("assimp.json");
+				return new THREE.AssimpJSONLoader( mgr );
 			case "babylon":
 				console.log("babylon");
 				return new THREE.BabylonLoader( mgr );


### PR DESCRIPTION
This addition is based on this mrdoob/three.js issue:
[(https://github.com/mrdoob/three.js/issues/5149)]

While this does seem to be an old issue/request and there are current many loader examples (at least one for each loader), it might still be useful to have an model viewer that could open ultimately all the supported model types. 

As such examples/wegl_loader_viewer.html is my initial attempt at meeting this goal. 

Currently my viewer can load most Mesh based model format but not Geometry based models. 

The camera currently zooms in on a bounding box but it does not work for all models. 

The controls are currently set on OrbitControls and not TrackballControls because I wanted to add a simple html dropdown to select a model. OrbitControls does support zoom in/out (scroll), rotate (primary click and drag), pan (alternate click and drag).  It might be possible to use TrackballControls with a more complex ui (such as settings on other examples). 


*****
Issue/Request:
[(https://github.com/mrdoob/three.js/issues/5149)]

Model viewer example #5149

"This is a request to add a model viewer example.
I think it's a very common need to display a model, pan, rotate and zoom.

Features:

Load models of different formats with plugable loaders. 
It can help unify the loaders API if needed.
Auto zoom the model to a reasonable initial value. Allow zoom in/out.
Use TrackballControls to rotate the model.
Allow pan."